### PR TITLE
Waving leaves support for cherry_leaves

### DIFF
--- a/shaders/block.properties
+++ b/shaders/block.properties
@@ -21,7 +21,7 @@ block.10004=grass fern oak_sapling spruce_sapling birch_sapling jungle_sapling a
 #else
 block.10004=tallgrass sapling deadbush yellow_flower red_flower wheat carrots potatoes beetroots pumpkin_stem melon_stem double_plant:half=lower
 #endif
-block.10008=leaves leaves2 oak_leaves spruce_leaves birch_leaves jungle_leaves acacia_leaves dark_oak_leaves azalea_leaves flowering_azalea_leaves mangrove_leaves
+block.10008=leaves leaves2 oak_leaves spruce_leaves birch_leaves jungle_leaves acacia_leaves dark_oak_leaves azalea_leaves flowering_azalea_leaves mangrove_leaves cherry_leaves
 block.10012=vine
 block.10016=reeds attached_pumpkin_stem attached_melon_stem mangrove_propagule seagrass tall_seagrass kelp_plant kelp hanging_roots sugar_cane spore_blossom
 block.10020=double_plant:half=upper sunflower:half=upper lilac:half=upper rose_bush:half=upper peony:half=upper tall_grass:half=upper large_fern:half=upper


### PR DESCRIPTION
Experiments can be enabled in 1.19.4 to add cherry blossom leaves to the world, so this change ensures that they will be affected by the waving leaves option.