### PR TITLE
update terrainMaterials.glsl to fix diagonal lines on modded ores

### DIFF
--- a/shaders/lib/materials/materialHandling/terrainMaterials.glsl
+++ b/shaders/lib/materials/materialHandling/terrainMaterials.glsl
@@ -49,14 +49,14 @@ if (mat < 10512) {
                             if (mat == 10024) { // Modded Ores
                                 #ifdef GLOWING_ORE_MODDED
                                     vec3 avgBorderColor = vec3(0.0);
-                                    avgBorderColor += texture2D(tex, midCoord + vec2( absMidCoordPos.x, absMidCoordPos.y)).rgb;
-                                    avgBorderColor += texture2D(tex, midCoord + vec2(-absMidCoordPos.x, absMidCoordPos.y)).rgb;
-                                    avgBorderColor += texture2D(tex, midCoord + vec2( absMidCoordPos.x,-absMidCoordPos.y)).rgb;
-                                    avgBorderColor += texture2D(tex, midCoord + vec2(-absMidCoordPos.x,-absMidCoordPos.y)).rgb;
-                                    avgBorderColor += texture2D(tex, midCoord + vec2(0.00001, absMidCoordPos.y)).rgb;
-                                    avgBorderColor += texture2D(tex, midCoord + vec2(0.00001,-absMidCoordPos.y)).rgb;
-                                    avgBorderColor += texture2D(tex, midCoord + vec2( absMidCoordPos.x, 0.00001)).rgb;
-                                    avgBorderColor += texture2D(tex, midCoord + vec2(-absMidCoordPos.x, 0.00001)).rgb;
+                                    avgBorderColor += texture2D(tex, vec2(1,1)).rgb;
+                                    avgBorderColor += texture2D(tex, vec2(0,1)).rgb;
+                                    avgBorderColor += texture2D(tex, vec2(1,0)).rgb;
+                                    avgBorderColor += texture2D(tex, vec2(0,0)).rgb;
+                                    avgBorderColor += texture2D(tex, vec2(0.5,1)).rgb;
+                                    avgBorderColor += texture2D(tex, vec2(0.5,0)).rgb;
+                                    avgBorderColor += texture2D(tex, vec2(1,0.5)).rgb;
+                                    avgBorderColor += texture2D(tex, vec2(0,0.5)).rgb;
                                     avgBorderColor *= 0.125;
 
                                     vec3 colorDif = abs(avgBorderColor - color.rgb);


### PR DESCRIPTION
gonna be perfectly honest, I don't have a fucking clue what this does differently

someone more intelligent than I am should probably test this before merging

before:
![2024-01-22_00 56 36](https://github.com/ComplementaryDevelopment/ComplementaryReimagined/assets/49025619/86cc9758-b89e-47a4-bc6b-c484ebbdcdb9)

after:
![2024-01-22_00 56 47](https://github.com/ComplementaryDevelopment/ComplementaryReimagined/assets/49025619/01afe9a9-cea9-4508-a4ac-a2467e441782)
