### PR TITLE
darknessFactor compile error

### DIFF
--- a/shaders/shaders.properties
+++ b/shaders/shaders.properties
@@ -196,5 +196,10 @@
     uniform.float.inSoulValley=smooth(54, if(in(biome, BIOME_SOUL_SAND_VALLEY), 1, 0), 15, 15)
 
     uniform.vec3.skyColorSmooth=vec3(smooth(20, skyColor.r, 5, 5), smooth(21, skyColor.g, 5, 5), smooth(22, skyColor.b, 5, 5))
-
+#if MC_VERSION >= 11900
     uniform.float.maxBlindnessDarkness=max(blindness, darknessFactor)
+#else
+    uniform.float.darknessFactor=0.0
+    uniform.float.darknessLightFactor=0.0
+    uniform.float.maxBlindnessDarkness=max(blindness, darknessFactor)
+#endif


### PR DESCRIPTION
On mc versions before 1.19 you get the error:
```
[14:43:47] [Render thread/WARN] [Oculus/]: Failed to resolve uniform maxBlindnessDarkness, reason: Unknown variable: darknessFactor ( = FunctionCall{max {[Id{blindness}, Id{darknessFactor}]} })
java.lang.RuntimeException: Unknown variable: darknessFactor
```
It doesn't seem to prevent other shaders from working but might reduce the compile time a tiny bit.