### PR TITLE
[Distant Horizons] Beacon beams depth-test

### DIFF
--- a/shaders/lib/util/spaceConversion.glsl
+++ b/shaders/lib/util/spaceConversion.glsl
@@ -26,3 +26,17 @@ vec3 ShadowClipToShadowView(vec3 pos) {
 vec3 ShadowViewToPlayer(vec3 pos) {
     return mat3(shadowModelViewInverse) * pos;
 }
+
+// Distant Horizon
+#ifdef DISTANT_HORIZONS
+
+vec3 ScreenToViewDH(vec3 pos) {
+    vec4 iProjDiag = vec4(dhProjectionInverse[0].x,
+                          dhProjectionInverse[1].y,
+                          dhProjectionInverse[2].zw);
+    vec3 p3 = pos * 2.0 - 1.0;
+    vec4 viewPos = iProjDiag * p3.xyzz + dhProjectionInverse[3];
+    return viewPos.xyz / viewPos.w;
+}
+
+#endif

--- a/shaders/program/gbuffers_beaconbeam.glsl
+++ b/shaders/program/gbuffers_beaconbeam.glsl
@@ -41,6 +41,19 @@ void main() {
     #else
         vec3 viewPos = ScreenToView(screenPos);
     #endif
+
+    #ifdef DISTANT_HORIZONS
+        vec3 screenPosDH = vec3(screenPos.xy, texture2D(dhDepthTex, screenPos.xy).r);
+        #ifdef TAA
+            vec3 viewPosDH = ScreenToViewDH(vec3(TAAJitter(screenPosDH.xy, -0.5), screenPosDH.z));
+        #else
+            vec3 viewPosDH = ScreenToViewDH(screenPosDH);
+        #endif
+
+        if (viewPos.z < viewPosDH.z)
+            discard;
+    #endif
+
     float lViewPos = length(viewPos);
 
     #ifdef IPBR


### PR DESCRIPTION
Add Distant Horizons depth-test when rendering the beacon beams (fixes the beams (ex: waypoints) going through DH terrain)