### PR TITLE
Add two more steps to Light Shaft Quality

### DIFF
--- a/shaders/lang/en_US.lang
+++ b/shaders/lang/en_US.lang
@@ -218,6 +218,8 @@ value.LIGHTSHAFT_QUALI_DEFINE.1=§eLow
 value.LIGHTSHAFT_QUALI_DEFINE.2=§eMedium
 value.LIGHTSHAFT_QUALI_DEFINE.3=§cHigh
 value.LIGHTSHAFT_QUALI_DEFINE.4=§4§lVery High
+value.LIGHTSHAFT_QUALI_DEFINE.5=§4§lUltra
+value.LIGHTSHAFT_QUALI_DEFINE.6=§4§l§n§oUltra+
 
 option.shadowDistance=Shadow Distance
 option.shadowDistance.comment=Adjusts the distance from the player which real-time shadows are rendered. §c[-]§r Lower values may cause excessive Light Shaft leaking.

--- a/shaders/lib/atmospherics/volumetricLight.glsl
+++ b/shaders/lib/atmospherics/volumetricLight.glsl
@@ -66,7 +66,11 @@ vec4 GetVolumetricLight(inout vec3 color, inout float vlFactor, vec3 translucent
         vlMult *= mix(VdotUM * VdotLM, 1.0, 0.4 * rainyNight) * vlTime;
         vlMult *= mix(invNoonFactor2 * 0.875 + 0.125, 1.0, max(vlSceneIntensity, rainFactor2));
 
-        #if LIGHTSHAFT_QUALI == 4
+        #if LIGHTSHAFT_QUALI == 6
+            int sampleCount = vlSceneIntensity < 0.5 ? 80 : 130;
+        #elif LIGHTSHAFT_QUALI == 5
+            int sampleCount = vlSceneIntensity < 0.5 ? 50 : 80;
+        #elif LIGHTSHAFT_QUALI == 4
             int sampleCount = vlSceneIntensity < 0.5 ? 30 : 50;
         #elif LIGHTSHAFT_QUALI == 3
             int sampleCount = vlSceneIntensity < 0.5 ? 15 : 30;

--- a/shaders/lib/common.glsl
+++ b/shaders/lib/common.glsl
@@ -21,7 +21,7 @@
     #define FXAA_DEFINE 1 //[-1 1]
     #define DETAIL_QUALITY 2 //[0 2 3]
     #define CLOUD_QUALITY 2 //[0 1 2 3]
-    #define LIGHTSHAFT_QUALI_DEFINE 2 //[0 1 2 3 4]
+    #define LIGHTSHAFT_QUALI_DEFINE 2 //[0 1 2 3 4 5 6]
     #define WATER_REFLECT_QUALITY 2 //[-1 0 1 2]
     #define BLOCK_REFLECT_QUALITY 3 //[0 1 3]
     #define ANISOTROPIC_FILTER 0 //[0 4 8 16]


### PR DESCRIPTION
Targeting `main` because `contribution` is behind.

I noticed that even on the highest quality the Light Shafts were still fairly grainy. TAA hides it pretty well but makes the image jittery. Turning TAA off for a super crisp and stable image makes the effect become really subpar.

## Some comparisons:
Changes are noticeable on the trees to the right of the cursor. Please open in a new tab and make sure the browser doesn't zoom in/out.

# Very High (30 50)
<img width="1920" height="1080" alt="Very High 30 50" src="https://github.com/user-attachments/assets/fdac1b85-4305-4f5d-bef9-530ad401234e" />
Currently the highest quality. Has noticeable grain and is especially bad during movement.

# Ultra (50 80), new
<img width="1920" height="1080" alt="Ultra 50 80" src="https://github.com/user-attachments/assets/ccd02396-1608-4bca-86b7-ede818c287db" />
Most of the grain is gone. You can still spot some grain during movement.

# Ultra+ (80 130), new
<img width="1920" height="1080" alt="Ultra+ 80 130" src="https://github.com/user-attachments/assets/a067638d-ddb2-49fb-b327-4d3e7b5d8766" />
Image is almost entirely stable now. Anything higher seems to be mostly placebo and makes my GPU no longer hit full speed. (75 fps, my monitor's refresh rate, on a RTX 3060 12G.)

---

For repro, these images were taken on GTNH 2.8.x. Full settings are:
```
BLOCK_REFLECT_QUALITY=0
CLOUD_QUALITY=3
CLOUD_SHADOWS=true
CLOUD_STYLE_DEFINE=1
FXAA_DEFINE=-1
GLOWING_ORE_MASTER=0
LIGHTSHAFT_QUALI_DEFINE=4
LIGHT_COLOR_MULTS=true
LIGHT_NIGHT_I=0.01
NETHER_STORM=false
SHADOW_QUALITY=5
SPECIAL_PORTAL_EFFECTS=false
SSAO_QUALI_DEFINE=0
TAA_MODE=0
VIGNETTE_R=false
```