### PR TITLE
Allow gamma/brightness mods to work by increasing clamp range for screen brightness

### DIFF
--- a/shaders/lib/common.glsl
+++ b/shaders/lib/common.glsl
@@ -670,7 +670,7 @@
     float invNoonFactor = 1.0 - noonFactor;
     float invNoonFactor2 = invNoonFactor * invNoonFactor;
 
-    float vsBrightness = clamp(screenBrightness, 0.0, 1.0);
+    float vsBrightness = clamp(screenBrightness, 0.0, 32.0);
 
     int modifiedWorldDay = int(mod(worldDay, 100) + 5.0);
     float syncedTime = (worldTime + modifiedWorldDay * 24000) * 0.05;


### PR DESCRIPTION
A lot of mods control or allow control of the screen brightness above 100%.  Clamping it to 1.0 effectively disables them all.   Clamping to 32.0 enables them all to work fine, with no obvious downside.
