### PR TITLE
Use basic shadow sampling if pixelation effects are in use

### DIFF
--- a/shaders/lib/lighting/shadowSampling.glsl
+++ b/shaders/lib/lighting/shadowSampling.glsl
@@ -78,6 +78,18 @@ vec3 SampleBasicFilteredShadow(vec3 shadowPos, float offset) {
     return vec3(shadow * 0.25);
 }
 
+vec3 SampleFilteredShadow(vec3 shadowPos, float offset, float colorMult, float colorPow) {
+    vec3 shadow = vec3(0.0);
+
+    for (int i = 0; i < 4; i++) {
+        shadow += SampleShadow(vec3(offset * shadowOffsets[i] + shadowPos.st, shadowPos.z), colorMult, colorPow);
+    }
+
+    shadow /= 8.0;
+
+    return shadow;
+}
+
 vec3 GetShadow(vec3 shadowPos, float lightmapY, float offset, int shadowSamples, bool leaves) {
     #if SHADOW_QUALITY > 0
         #if ENTITY_SHADOW <= 1 && defined GBUFFERS_BLOCK
@@ -104,7 +116,7 @@ vec3 GetShadow(vec3 shadowPos, float lightmapY, float offset, int shadowSamples,
         #ifndef DO_PIXELATION_EFFECTS
             vec3 shadow = SampleTAAFilteredShadow(shadowPos, offset, shadowSamples, leaves, colorMult, colorPow);
         #else
-            vec3 shadow = SampleBasicFilteredShadow(shadowPos, offset);
+            vec3 shadow = SampleFilteredShadow(shadowPos, offset, colorMult, colorPow);
         #endif
     #else
         vec3 shadow = SampleBasicFilteredShadow(shadowPos, offset);

--- a/shaders/lib/lighting/shadowSampling.glsl
+++ b/shaders/lib/lighting/shadowSampling.glsl
@@ -101,7 +101,11 @@ vec3 GetShadow(vec3 shadowPos, float lightmapY, float offset, int shadowSamples,
     float colorPow = mix(1.5 + 0.5 * float(isEyeInWater == 0), 0.5, pow2(pow2(lightmapY)));
 
     #if SHADOW_QUALITY >= 1
-        vec3 shadow = SampleTAAFilteredShadow(shadowPos, offset, shadowSamples, leaves, colorMult, colorPow);
+        #ifndef DO_PIXELATION_EFFECTS
+            vec3 shadow = SampleTAAFilteredShadow(shadowPos, offset, shadowSamples, leaves, colorMult, colorPow);
+        #else
+            vec3 shadow = SampleBasicFilteredShadow(shadowPos, offset);
+        #endif
     #else
         vec3 shadow = SampleBasicFilteredShadow(shadowPos, offset);
     #endif

--- a/shaders/lib/lighting/shadowSampling.glsl
+++ b/shaders/lib/lighting/shadowSampling.glsl
@@ -85,9 +85,7 @@ vec3 SampleFilteredShadow(vec3 shadowPos, float offset, float colorMult, float c
         shadow += SampleShadow(vec3(offset * shadowOffsets[i] + shadowPos.st, shadowPos.z), colorMult, colorPow);
     }
 
-    shadow /= 8.0;
-
-    return shadow;
+    return shadow / 8.0;
 }
 
 vec3 GetShadow(vec3 shadowPos, float lightmapY, float offset, int shadowSamples, bool leaves) {


### PR DESCRIPTION
Using jittered sampling with pixelated shadows causes dot crawl artifacts, which are especially noticeable on lower shadow qualities. This PR forces basic filtering if pixelated shadows are enabled. As far as I can tell this doesn't break anything. Not really sure what performance implications of this are, but I feel like the impact is probably next to nothing.

<img width="1920" height="1080" alt="comparison" src="https://github.com/user-attachments/assets/dc660d7f-faae-4972-89f2-9aebe16e56f9" />

TAA turned off for clarity, the artifacting is still there with it on.