### PR TITLE
Fix faint lightshafts when Voxy/Distant Horizons is enabled

### DIFF
--- a/shaders/lib/atmospherics/volumetricLight/volumetricLight.glsl
+++ b/shaders/lib/atmospherics/volumetricLight/volumetricLight.glsl
@@ -94,9 +94,11 @@ vec4 GetVolumetricLight(inout float vlFactor, vec3 translucentMult, float lViewP
 
         float maxDistance = far * 0.98; // The distance where the fog is 1.0 and we stop tracing
         float qualityThreshold = min(far, shadowDistance) * 0.98; // Only use farSamples from this point on to hit our maxDistance. Set higher than maxDistance to disable far samples
-        
+
         #if defined VOXY || defined DISTANT_HORIZONS
-            maxDistance = renderDistance * 0.5; // Covers lod chunks
+            // loddedMaxDistance is only used for sky pixels — non-sky pixels keep maxDistance = far
+            // so weight normalization isn't diluted by a large LOD render distance
+            float loddedMaxDistance = max(renderDistance * 0.5, maxDistance);
 
             fogCurve = 0.7;
             fogCurveIntense *= 1.0 - 0.5 * rainFactor;
@@ -142,7 +144,11 @@ vec4 GetVolumetricLight(inout float vlFactor, vec3 translucentMult, float lViewP
 
     vec3 nViewPosInSceneSpace = normalize(mat3(gbufferModelViewInverse) * nViewPos);
     vec3 rayDirection = nViewPosInSceneSpace;
-    float rayEnd = !sky ? min(lViewPos1, maxDistance) : maxDistance; 
+    float rayEnd = !sky ? min(lViewPos1, maxDistance) : maxDistance;
+    #if defined VOXY || defined DISTANT_HORIZONS
+        // Sky pixels trace into LOD chunks; update maxDistance so weights normalize correctly
+        if (sky) { rayEnd = loddedMaxDistance; maxDistance = loddedMaxDistance; }
+    #endif
     float lastDistance = 0.0;
 
     #if defined END && !defined VOXY && !defined DISTANT_HORIZONS


### PR DESCRIPTION
## What's the issue

When Voxy or Distant Horizons is enabled, lightshafts appear very faint — sometimes nearly invisible depending on how large the LOD render distance is set.

## Root cause

In `volumetricLight.glsl`, the Voxy/DH branch sets `maxDistance = renderDistance * 0.5` for all pixels. The weight accumulation normalises against `maxDistance`:

```glsl
float sliceWeight = smoothstep1(pow(nextDistance / maxDistance, fogCurve))
                  - smoothstep1(pow(lastDistance / maxDistance, fogCurve));
```

With a large LOD render distance (e.g. 512 chunks → `maxDistance = 4096`), a ray that stops at vanilla geometry (~192 blocks) only accumulates ~4% of the expected weight. The effect scales badly — the larger the Voxy render distance the user has set, the fainter the shafts.

## Fix

Decouple the weight-normalisation distance from the LOD extension distance:

- **Non-sky pixels** keep `maxDistance = far * 0.98` — weight normalisation is identical to non-Voxy behaviour, so lightshafts are full brightness regardless of LOD render distance setting.
- **Sky pixels** (both vanilla and LOD depth are 1.0) use `loddedMaxDistance = max(renderDistance * 0.5, far * 0.98)` — the ray still extends into the LOD zone and weights correctly integrate to 1.0.

## Files changed

- `shaders/lib/atmospherics/volumetricLight/volumetricLight.glsl`